### PR TITLE
arm64: dts: imx8mp-var-dart: Enable xcvr

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-var-dart-dt8mcustomboard.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-var-dart-dt8mcustomboard.dts
@@ -148,6 +148,12 @@
 				<192000>;
 		status = "okay";
 	};
+
+	sound-xcvr {
+		compatible = "fsl,imx-audio-xcvr";
+		model = "imx-audio-xcvr";
+		cpu-dai = <&xcvr>;
+	};
 };
 
 &aud2htx {
@@ -625,6 +631,11 @@
 &ldo4 {
 	regulator-min-microvolt = <1800000>;
 	regulator-max-microvolt = <1800000>;
+};
+
+&xcvr {
+	#sound-dai-cells = <0>;
+	status = "okay";
 };
 
 &iomuxc {


### PR DESCRIPTION
NXP XCVR (Audio Transceiver) is a on-chip functional module that allows CPU to receive and transmit digital audio via HDMI2.1 eARC, HDMI1.4 ARC and SPDIF.